### PR TITLE
shorten the name to hashchange

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@
 
 Browserify
 
-    $ npm install --save green-mesa-hashchange
+    $ npm install --save hashchange
 
 Component
 

--- a/package.json
+++ b/package.json
@@ -1,21 +1,26 @@
 {
-  "name"          : "green-mesa-hashchange",
-  "description"   : "Hash Change event handler thingy",
-  "keywords"      : ["event", "hash", "client", "browser"],
-  "author"        : "Visionmedia",
-  "dependencies"  : {
-    "foreach" : "2.0.4",
-    "component-indexof" : "0.0.3"
+  "name": "hashchange",
+  "description": "hash change event handler thingy",
+  "version": "0.1.4",
+  "author": "charlottegore",
+  "browser": {
+    "each": "foreach",
+    "indexof": "component-indexof"
   },
-  "main"          : "index.js",
-  "version"       : "0.1.4",
-  "license"       : "MIT",
+  "dependencies": {
+    "component-indexof": "0.0.3",
+    "foreach": "2.0.4"
+  },
+  "keywords": [
+    "browser",
+    "client",
+    "event",
+    "hash"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/green-mesa/hashchange.git"
-  },
-  "browser" : {
-    "each" : "foreach",
-    "indexof" : "component-indexof"
   }
 }


### PR DESCRIPTION
Hi @CharlotteGore,

As I promised back in January, I have cleared the `hashchange` namespace for your module. The original author hasn't responded to my inquiries, so I've added you as an owner. To take over the name, you'll need to do the following:

1.  merge this PR, or make whatever changes you want to make. The most important thing is changing the name in package.json to `hashchange`
1. run `npm version major -m "one point oh!"`. This major version bump to 1.0.0 will mean that anyone using the old `hashchange` with a semver range like `0.0.x` or `0.0.1` will be unaffected by the replacement. There are not likely to be any users on the old version, but this is a good general practice.

Thanks!